### PR TITLE
add row separator option

### DIFF
--- a/examples/row-separator.lua
+++ b/examples/row-separator.lua
@@ -1,0 +1,38 @@
+local tp = require "tprint"
+
+local list = {
+  {item = "socks",    price=10,  qty=5,  discount=0, note="nice and warm"},
+  {item = "gloves",   price=55,  qty=25, discount=0.4, note="made of wool"},
+  {item = "cardigan", price=255, qty=11, discount=0.1, note="a bit pricey"},
+  {item = "hat",      price=44,  qty=33, discount=0.2, note="old fashioned"},
+  {item = "shoes",    price=155, qty=4,  discount=0, note="for running"},
+}
+
+-- add row separators on row 2 and 4
+print(tp(list,{column={"item","note","price","discount","qty"}, rowSeparator={2, 4}, frame=tp.FRAME_ASCII}), "\n")
+
+-- add row separator on first row
+print(tp(list,{column={"item","note","price","discount","qty"}, rowSeparator={1}, frame=tp.FRAME_ASCII}), "\n")
+
+local _, msg, err
+
+-- example of invalid setting
+
+function err()
+  print(tp(list,{column={"item","note","price","discount","qty"},
+                 rowSeparator="wrong"}), "\n")
+end
+
+_, msg = pcall(err)
+print(msg)
+
+
+-- example of invalid setting
+
+function err()
+  print(tp(list,{column={"item","note","price","discount","qty"},
+                 rowSeparator=2}), "\n")
+end
+
+_, msg = pcall(err)
+print(msg)

--- a/spec/row-separator.expected
+++ b/spec/row-separator.expected
@@ -1,0 +1,25 @@
++--------+-------------+-----+--------+---+
+|item    |note         |price|discount|qty|
++--------+-------------+-----+--------+---+
+|socks   |nice and warm|   10|       0|  5|
+|gloves  |made of wool |   55|     0.4| 25|
++--------+-------------+-----+--------+---+
+|cardigan|a bit pricey |  255|     0.1| 11|
+|hat     |old fashioned|   44|     0.2| 33|
++--------+-------------+-----+--------+---+
+|shoes   |for running  |  155|       0|  4|
++--------+-------------+-----+--------+---+	
+
++--------+-------------+-----+--------+---+
+|item    |note         |price|discount|qty|
++--------+-------------+-----+--------+---+
+|socks   |nice and warm|   10|       0|  5|
++--------+-------------+-----+--------+---+
+|gloves  |made of wool |   55|     0.4| 25|
+|cardigan|a bit pricey |  255|     0.1| 11|
+|hat     |old fashioned|   44|     0.2| 33|
+|shoes   |for running  |  155|       0|  4|
++--------+-------------+-----+--------+---+	
+
+examples/row-separator.lua:22: invalid option 'value' (table expected)
+examples/row-separator.lua:33: invalid option 'value' (table expected)

--- a/tprint.lua
+++ b/tprint.lua
@@ -612,6 +612,9 @@ function mt:__tostring()
     for i in ipairs(row[1]) do
       out(eansi(frame[5]),table.concat(M.map(row,i), eansi(rc..frame[7])),eansi(frame[8]),"\n")
     end
+    if self.rowSeparator[l] and l < self.rows then
+      out(eansi(frame[9]),table.concat(tsep,frame[11]),eansi(frame[12]),"\n")
+    end
   end
 
   -- footer separator
@@ -725,6 +728,16 @@ function M.new(t, options)
   -- draw header and footer separator line
   o.headerSeparator = o.headerSeparator == nil and type(o.header) == "table" or o.headerSeparator
   o.footerSeparator = o.footerSeparator == nil and o.footer ~= nil or o.footerSeparator
+
+  fassert(type(o.rowSeparator)=="table" or o.rowSeparator == nil,
+    "invalid option 'value' (table expected)")
+  o.rowSeparator = o.rowSeparator or {}
+  local separator_map = {}
+  for _, row in ipairs(o.rowSeparator) do
+    separator_map[row] = true
+  end
+  o.rowSeparator = separator_map
+
 
   -- value = optional functions to apply to every item by columns: f(self,val) -> value
   fassert(type(o.value)=="table" or type(o.value)=="function" or o.value == nil,


### PR DESCRIPTION
Give the ability to add row separators for tables with frames that do not have row separators by default. It uses the table header/ footer separator.

Useful for my use case. I will probably later add a column separator as well. Up to you if you believe something like this should be added.